### PR TITLE
Initial implementation of Type-safe Setting Names / Paths and Schema definition

### DIFF
--- a/src/profile/RetroTinkProfile.spec.ts
+++ b/src/profile/RetroTinkProfile.spec.ts
@@ -5,6 +5,7 @@ import {
   SettingNotSupportedError,
 } from '../exceptions/RetroTinkProfileException';
 import { RetroTinkSetting, RetroTinkSettingValue, RetroTinkSettingsValues } from '../settings/RetroTinkSetting';
+import { RetroTinkSettingName, RetroTinkSettingPath } from '../settings/Schema';
 import RetroTinkProfile from './RetroTinkProfile';
 import { bad_setting_json_str, invalid_json, pretty_json_str, unpretty_json_str } from './__fixtures__/json_profiles';
 
@@ -120,7 +121,7 @@ describe('RetroTinkProfile', () => {
     });
     test('should throw for an invalid setting', async () => {
       const profile = await RetroTinkProfile.build(`${__dirname}/__fixtures__/mask-enabled-strength-10.rt4`);
-      expect(() => profile.getValue('some.bunko.setting')).toThrow(SettingNotSupportedError);
+      expect(() => profile.getValue('some.bunko.setting' as RetroTinkSettingName)).toThrow(SettingNotSupportedError);
     });
   });
   describe('setValues', () => {
@@ -154,7 +155,7 @@ describe('RetroTinkProfile', () => {
       const profile = await RetroTinkProfile.build();
       const setting = new RetroTinkSettingValue(
         {
-          name: 'something.unsupported',
+          name: 'something.unsupported' as RetroTinkSettingPath,
         } as RetroTinkSetting,
         new Uint8Array([250]),
       );

--- a/src/settings/RetroTinkSetting.spec.ts
+++ b/src/settings/RetroTinkSetting.spec.ts
@@ -6,6 +6,9 @@ import {
   RetroTinkSettingsValues,
 } from '../settings/RetroTinkSetting';
 import { DataType } from './DataType';
+import { RetroTinkSettingPath } from './Schema';
+
+const name = 'some.retrotink.setting' as RetroTinkSettingPath;
 
 describe('RetroTinkSetting', () => {
   describe('RetroTinkSettingsValues', () => {
@@ -21,7 +24,7 @@ describe('RetroTinkSetting', () => {
         const settings = new RetroTinkSettingsValues();
         const v = new RetroTinkSettingValue(
           new RetroTinkSetting({
-            name: 'some.retrotink.sibling_1',
+            name: 'some.retrotink.sibling_1' as RetroTinkSettingPath,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -31,7 +34,7 @@ describe('RetroTinkSetting', () => {
         settings.set(v.name, v);
         const v2 = new RetroTinkSettingValue(
           new RetroTinkSetting({
-            name: 'some.retrotink.sibling_2',
+            name: 'some.retrotink.sibling_2' as RetroTinkSettingPath,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x000d, length: 1 }],
             type: DataType.STR,
@@ -41,7 +44,7 @@ describe('RetroTinkSetting', () => {
         settings.set(v2.name, v2);
         const v3 = new RetroTinkSettingValue(
           new RetroTinkSetting({
-            name: 'some.uncle',
+            name: 'some.uncle' as RetroTinkSettingPath,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.ENUM,
@@ -94,7 +97,7 @@ describe('RetroTinkSetting', () => {
     describe('asPlainObject', () => {
       describe('DataType.STR', () => {
         const s = new RetroTinkSetting({
-          name: 'some.retrotink.setting',
+          name,
           desc: 'Any Setting',
           byteRanges: [{ address: 0x0000, length: 12 }],
           type: DataType.STR,
@@ -112,7 +115,7 @@ describe('RetroTinkSetting', () => {
       });
       describe('DataType.INT', () => {
         const s = new RetroTinkSetting({
-          name: 'some.retrotink.setting',
+          name,
           desc: 'Any Setting',
           byteRanges: [{ address: 0x0000, length: 1 }],
           type: DataType.INT,
@@ -130,7 +133,7 @@ describe('RetroTinkSetting', () => {
       });
       describe('DataType.ENUM', () => {
         const s = new RetroTinkSetting({
-          name: 'some.retrotink.setting',
+          name,
           desc: 'Any Setting',
           byteRanges: [{ address: 0x0000, length: 1 }],
           type: DataType.ENUM,
@@ -153,7 +156,7 @@ describe('RetroTinkSetting', () => {
       });
       describe('DataType.BIT', () => {
         const s = new RetroTinkSetting({
-          name: 'some.retrotink.setting',
+          name,
           desc: 'Any Setting',
           byteRanges: [{ address: 0x0000, length: 1 }],
           type: DataType.BIT,
@@ -174,7 +177,7 @@ describe('RetroTinkSetting', () => {
       describe('DataType.STR', () => {
         test('should set with string', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: DataType.STR,
@@ -212,7 +215,7 @@ describe('RetroTinkSetting', () => {
 
         test('should return boolean from asBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.STR,
@@ -226,7 +229,7 @@ describe('RetroTinkSetting', () => {
 
         test('should parse fromBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 5 }],
             type: DataType.STR,
@@ -252,7 +255,7 @@ describe('RetroTinkSetting', () => {
       describe('DataType.INT', () => {
         test('should set with string', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -264,7 +267,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with number', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -277,7 +280,7 @@ describe('RetroTinkSetting', () => {
 
         test('should return boolean from asBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -290,7 +293,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should parse fromBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -304,7 +307,7 @@ describe('RetroTinkSetting', () => {
 
         test('should throw if type not implemented in asInt()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 8 }],
             type: DataType.INT,
@@ -314,7 +317,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw if type not implemented in fromInt()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 8 }],
             type: DataType.INT,
@@ -324,7 +327,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw if out of range', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -334,7 +337,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with boolean', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -346,7 +349,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw if not a number', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -356,7 +359,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw with unexpected type', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.INT,
@@ -368,7 +371,7 @@ describe('RetroTinkSetting', () => {
       describe('DataType.SIGNED_INT', () => {
         test('should set with string', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -380,7 +383,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with number', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -392,7 +395,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should parse fromBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -405,7 +408,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw if out of range', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -415,7 +418,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with boolean', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -427,7 +430,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw if not a number', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -437,7 +440,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw with unexpected type', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.SIGNED_INT,
@@ -449,7 +452,7 @@ describe('RetroTinkSetting', () => {
       describe('DataType.BIT', () => {
         test('should set with string', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
@@ -464,7 +467,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw with invalid string', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
@@ -513,7 +516,7 @@ describe('RetroTinkSetting', () => {
         });
         test('should return boolean from asBoolean()', () => {
           const s = new RetroTinkSetting({
-            name: 'some.retrotink.setting',
+            name,
             desc: 'Any Setting',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
@@ -537,7 +540,7 @@ describe('RetroTinkSetting', () => {
       });
       describe('DataType.ENUM', () => {
         const s = new RetroTinkSetting({
-          name: 'some.retrotink.setting',
+          name,
           desc: 'Some value from a set of predefined choices',
           byteRanges: [{ address: 0x0000, length: 1 }],
           type: DataType.ENUM,

--- a/src/settings/RetroTinkSetting.ts
+++ b/src/settings/RetroTinkSetting.ts
@@ -5,6 +5,7 @@ import {
 } from '../exceptions/RetroTinkProfileException';
 import { addValueToObject, deepMerge } from '../utils/ObjectUtils';
 import { DataType } from './DataType';
+import { RetroTinkSettingName, RetroTinkSettingPath } from './Schema';
 
 interface ByteRange {
   address: number;
@@ -12,7 +13,7 @@ interface ByteRange {
 }
 
 interface RetroTinkSettingParams {
-  name: string;
+  name: RetroTinkSettingPath;
   desc: string;
   byteRanges: ByteRange[];
   type: DataType;
@@ -25,7 +26,7 @@ interface RetroTinkEnumValue {
 }
 
 export class RetroTinkSetting {
-  name: string;
+  name: RetroTinkSettingPath;
   desc: string;
   byteRanges: ByteRange[];
   type: DataType;
@@ -51,7 +52,7 @@ class RetroTinkBaseSettings<T extends RetroTinkSetting> extends Map<string, T> {
     super(settings.map((s) => [s.name, s]));
   }
 
-  get(key: string): T {
+  get<S extends RetroTinkSettingName>(key: S): T {
     if (!this.has(key)) throw new SettingNotSupportedError(key);
     return super.get(key);
   }

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -1,0 +1,200 @@
+import { DataType } from './DataType';
+import { RetroTinkSetting, RetroTinkSettings } from './RetroTinkSetting';
+
+export type Primitive = string | number | boolean;
+
+// The terminal nodes that hold the value, in the schema
+type SettingName<T, K extends string = ''> = {
+  [P in keyof T]: T[P] extends Primitive
+    ? K extends ''
+      ? `${P & string}`
+      : `${K}.${P & string}`
+    : T[P] extends object
+      ? SettingName<T[P], K extends '' ? `${P & string}` : `${K}.${P & string}`>
+      : never;
+}[keyof T];
+
+export type RetroTinkSettingName = SettingName<RetroTinkSettingsSchema>;
+
+// The "intermediate" nodes that represent groups of settings that hold terminal nodes
+type SettingPath<T, K extends keyof T = keyof T> = K extends string
+  ? T[K] extends object
+    ? K | `${K}.${SettingPath<T[K]>}`
+    : K
+  : never;
+
+export type RetroTinkSettingPath = SettingPath<RetroTinkSettingsSchema> | RetroTinkSettingName;
+
+export type RetroTinkSettingsSchema = {
+  header: string;
+  input: string;
+  output: {
+    resolution: string;
+    transmitter: {
+      hdr: string;
+      colorimetry: string;
+      rgb_range: string;
+      sync_lock: string;
+      vrr: string;
+      deep_color: boolean;
+    };
+  };
+  advanced: {
+    effects: {
+      scanline: {
+        intensity: number;
+        thickness: number;
+      };
+      mask: {
+        path: string;
+        enabled: boolean;
+        strength: number;
+      };
+    };
+  };
+};
+
+export const RetroTinkSettingsVersion = {
+  '1.4.2': new RetroTinkSettings([
+    new RetroTinkSetting({
+      name: 'header',
+      desc: 'File Header',
+      byteRanges: [{ address: 0x0000, length: 12 }],
+      type: DataType.STR,
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.effects.mask.enabled',
+      desc: 'Advanced -> Processing -> Mask -> Enabled',
+      byteRanges: [{ address: 0x008c, length: 1 }],
+      type: DataType.BIT,
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.effects.mask.strength',
+      desc: 'Advanced -> Processing -> Mask -> Strength',
+      byteRanges: [{ address: 0x02a0, length: 1 }],
+      type: DataType.SIGNED_INT,
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.effects.mask.path',
+      desc: 'Advanced -> Processing -> Mask -> Path',
+      byteRanges: [{ address: 0x0090, length: 256 }],
+      type: DataType.STR,
+    }),
+    new RetroTinkSetting({
+      name: 'input',
+      desc: 'Input',
+      byteRanges: [
+        { address: 0x0368, length: 1 },
+        { address: 0x5869, length: 1 },
+      ],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'HDMI', value: new Uint8Array([5, 0]) },
+        { name: 'Front|Composite', value: new Uint8Array([3, 3]) },
+        { name: 'Front|S-Video', value: new Uint8Array([3, 4]) },
+        { name: 'RCA|YPbPr', value: new Uint8Array([0, 7]) },
+        { name: 'RCA|RGsB', value: new Uint8Array([0, 8]) },
+        { name: 'RCA|CVBS on Green', value: new Uint8Array([0, 9]) },
+        { name: 'SCART|RGBS (75 Ohm)', value: new Uint8Array([2, 12]) },
+        { name: 'SCART|RGsB', value: new Uint8Array([2, 13]) },
+        { name: 'SCART|YPbPr', value: new Uint8Array([2, 14]) },
+        { name: 'SCART|CVBS on Pin 20', value: new Uint8Array([2, 15]) },
+        { name: 'SCART|CVBS on Green', value: new Uint8Array([2, 16]) },
+        { name: 'SCART|Y/C on Pin 20/Red', value: new Uint8Array([2, 17]) },
+        { name: 'HD-15|RGBHV', value: new Uint8Array([1, 20]) },
+        { name: 'HD-15|RGBS', value: new Uint8Array([1, 21]) },
+        { name: 'HD-15|RGsB', value: new Uint8Array([1, 22]) },
+        { name: 'HD-15|YPbPr', value: new Uint8Array([1, 23]) },
+        { name: 'HD-15|CVBS on Hsync', value: new Uint8Array([1, 24]) },
+        { name: 'HD-15|CVBS on Green', value: new Uint8Array([1, 25]) },
+        { name: 'HD-15|Y/C on Green/Red', value: new Uint8Array([1, 26]) },
+        { name: 'HD-15|Y/C on G/R (Enh.)', value: new Uint8Array([1, 27]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.resolution',
+      desc: 'HDMI Output -> Resolution',
+      byteRanges: [{ address: 0x36c, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: '4K60', value: new Uint8Array([0]) },
+        { name: '4K50', value: new Uint8Array([1]) },
+        { name: '1080p60', value: new Uint8Array([2]) },
+        { name: '1080p50', value: new Uint8Array([3]) },
+        { name: '1440p60', value: new Uint8Array([4]) },
+        { name: '1440p50', value: new Uint8Array([5]) },
+        { name: '1080p100', value: new Uint8Array([6]) },
+        { name: '1440p100', value: new Uint8Array([7]) },
+        { name: '1080p120', value: new Uint8Array([8]) },
+        { name: '1440p120', value: new Uint8Array([9]) },
+        { name: '480p60', value: new Uint8Array([13]) },
+        { name: 'Custom 1', value: new Uint8Array([69]) },
+        { name: 'Custom 2', value: new Uint8Array([70]) },
+        { name: 'Custom 3', value: new Uint8Array([71]) },
+        { name: 'Custom 4', value: new Uint8Array([72]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.hdr',
+      desc: 'HDMI Output -> Transmitter -> HDR',
+      byteRanges: [{ address: 0x2d0, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Off', value: new Uint8Array([0]) },
+        { name: 'HDR10 [8-bit]', value: new Uint8Array([1]) },
+        { name: 'HLG [8-bit]', value: new Uint8Array([2]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.colorimetry',
+      desc: 'HDMI Output -> Transmitter -> Colorimetry',
+      byteRanges: [{ address: 0x1ec8, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Auto-Rec.709', value: new Uint8Array([0]) },
+        { name: 'Rec.709', value: new Uint8Array([1]) },
+        { name: 'Rec.2020', value: new Uint8Array([2]) },
+        { name: 'Adobe RGB', value: new Uint8Array([3]) },
+        { name: 'Display-P3', value: new Uint8Array([4]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.rgb_range',
+      desc: 'HDMI Output -> Transmitter -> RGB Range',
+      byteRanges: [{ address: 0x1f08, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Full', value: new Uint8Array([0]) },
+        { name: 'Limited', value: new Uint8Array([1]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.sync_lock',
+      desc: 'HDMI Output -> Transmitter -> Sync Lock',
+      byteRanges: [{ address: 0x2d8, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Triple Buffer', value: new Uint8Array([0]) },
+        { name: 'Gen Lock', value: new Uint8Array([1]) },
+        { name: 'Frame Lock', value: new Uint8Array([2]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.vrr',
+      desc: 'HDMI Output -> Transmitter -> VRR',
+      byteRanges: [{ address: 0x2dc, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Off', value: new Uint8Array([0]) },
+        { name: 'FreeSync', value: new Uint8Array([1]) },
+        { name: 'VESA', value: new Uint8Array([2]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'output.transmitter.deep_color',
+      desc: 'HDMI Output -> Transmitter -> Deep Color',
+      byteRanges: [{ address: 0x2d4, length: 1 }],
+      type: DataType.BIT,
+    }),
+  ]),
+};

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -1,3 +1,5 @@
+import { Primitive } from '../settings/Schema';
+
 export function isObject(item: unknown): boolean {
   return item && typeof item === 'object' && !Array.isArray(item);
 }
@@ -31,8 +33,6 @@ export function addValueToObject<T>(obj: Record<string, unknown>, keys: string[]
     addValueToObject(obj[key] as Record<string, unknown>, keys.slice(1), value);
   }
 }
-
-type Primitive = string | number | boolean;
 
 type NestedObject = {
   [key: string]: Primitive | NestedObject;


### PR DESCRIPTION
We can now get compile-time type-safety when referring to full Setting Names, or partial Setting Paths. 

I also moved the definition of the profile settings from `RetroTinkProfile` into `Schema.ts`. I export those as an element of a constant `RetroTinkSettingsVersion`.

I'm going to punt on a more fully-featured versioning abstraction until later, should the need ever reveal itself. 