### PR TITLE
Implement "Ready Only" abstraction as a type

### DIFF
--- a/src/settings/RetroTinkSetting.ts
+++ b/src/settings/RetroTinkSetting.ts
@@ -1,6 +1,5 @@
 import {
   SettingNotSupportedError,
-  SettingNotWritableError,
   SettingTypeError,
   SettingValidationError,
 } from '../exceptions/RetroTinkProfileException';
@@ -173,7 +172,6 @@ export class RetroTinkSettingValue extends RetroTinkSetting {
   }
 
   set(val: string | number | boolean) {
-    if (this instanceof RetroTinkReadOnlySetting) throw new SettingNotWritableError(this.name);
     if (typeof val === 'string') {
       switch (this.type) {
         case DataType.STR:
@@ -228,7 +226,6 @@ export class RetroTinkSettingValue extends RetroTinkSetting {
   }
 
   private fromString(str: string): void {
-    if (this instanceof RetroTinkReadOnlySetting) throw new SettingNotWritableError(this.name);
     const length = this.length();
     this.value = new Uint8Array(length);
     if (this.type == DataType.BIT) {
@@ -263,7 +260,6 @@ export class RetroTinkSettingValue extends RetroTinkSetting {
   }
 
   private fromInt(num: number): void {
-    if (this instanceof RetroTinkReadOnlySetting) throw new SettingNotWritableError(this.name);
     const length = this.length();
     this.value = new Uint8Array(length);
     if (this.type == DataType.ENUM) {
@@ -295,7 +291,6 @@ export class RetroTinkSettingValue extends RetroTinkSetting {
   }
 
   private fromBool(bool: boolean): void {
-    if (this instanceof RetroTinkReadOnlySetting) throw new SettingNotWritableError(this.name);
     const length = this.length();
     this.value = new Uint8Array(length);
     if (length > 0) {

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -1,5 +1,5 @@
 import { DataType } from './DataType';
-import { RetroTinkSetting, RetroTinkSettings } from './RetroTinkSetting';
+import { RetroTinkReadOnlySetting, RetroTinkSetting, RetroTinkSettings } from './RetroTinkSetting';
 
 export type Primitive = string | number | boolean;
 
@@ -68,12 +68,11 @@ export type RetroTinkSettingsSchema = {
 
 export const RetroTinkSettingsVersion = {
   '1.4.2': new RetroTinkSettings([
-    new RetroTinkSetting({
+    new RetroTinkReadOnlySetting({
       name: 'header' as RetroTinkSettingName,
       desc: 'File Header (Read-Only)',
       byteRanges: [{ address: 0x0000, length: 12 }],
       type: DataType.STR,
-      readOnly: true,
     }),
     new RetroTinkSetting({
       name: 'advanced.effects.mask.enabled',


### PR DESCRIPTION
Initial implementation was a property on `RetroTinkSetting`, but it - arguably - makes more sense as a subclass, and therefore a "special case" of `RetroTinkSetting` .

That may be splitting hairs, but it feels as if it gives us more options going forward, without having to unnecessarily burden the base class with a new property.