### PR TITLE
Implement `header` as a `RetroTinkReadOnlySetting`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt4k-profile",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "A Typescript Library for Reading and Writing RetroTINK-4k .rt4 Profiles",
   "main": "dist/index.js",
   "exports": {

--- a/src/exceptions/RetroTinkProfileException.ts
+++ b/src/exceptions/RetroTinkProfileException.ts
@@ -26,6 +26,12 @@ export class SettingNotSupportedError extends RetroTinkProfileError {
   }
 }
 
+export class SettingNotWritableError extends RetroTinkProfileError {
+  constructor(settingKey: string, message = `Setting is Read-Only and may not be set directly: ${settingKey}`) {
+    super(message);
+  }
+}
+
 export class SettingTypeError extends RetroTinkProfileError {
   constructor(
     settingKey: string,

--- a/src/profile/RetroTinkProfile.spec.ts
+++ b/src/profile/RetroTinkProfile.spec.ts
@@ -6,7 +6,7 @@ import {
   SettingNotWritableError,
 } from '../exceptions/RetroTinkProfileException';
 import { RetroTinkSetting, RetroTinkSettingValue, RetroTinkSettingsValues } from '../settings/RetroTinkSetting';
-import { RetroTinkSettingName, RetroTinkSettingPath } from '../settings/Schema';
+import { RetroTinkSettingName } from '../settings/Schema';
 import RetroTinkProfile from './RetroTinkProfile';
 import { bad_setting_json_str, invalid_json, pretty_json_str, unpretty_json_str } from './__fixtures__/json_profiles';
 import { readFileBinarySync, writeFileBinary, writeFileBinarySync } from '../utils/FileUtils';
@@ -160,7 +160,7 @@ describe('RetroTinkProfile', () => {
     });
     test('should throw when attempting to persist read-only settings', async () => {
       const profile = await RetroTinkProfile.build();
-      let settings = profile.getValues();
+      const settings = profile.getValues();
       const s = new RetroTinkSetting({
         name: 'header' as RetroTinkSettingName,
         desc: 'File Header',
@@ -169,12 +169,12 @@ describe('RetroTinkProfile', () => {
       });
       const v = new RetroTinkSettingValue(s);
 
-      settings.set('header' as RetroTinkSettingName, v)
-      expect(() => profile.setValues(settings)).toThrow(SettingNotWritableError); 
+      settings.set('header' as RetroTinkSettingName, v);
+      expect(() => profile.setValues(settings)).toThrow(SettingNotWritableError);
     });
     test('should throw when attempting to persist invalid settings', async () => {
       const profile = await RetroTinkProfile.build();
-      let settings = profile.getValues();
+      const settings = profile.getValues();
       const s = new RetroTinkSetting({
         name: 'garbage' as RetroTinkSettingName,
         desc: 'garbage',
@@ -183,8 +183,8 @@ describe('RetroTinkProfile', () => {
       });
       const v = new RetroTinkSettingValue(s);
 
-      settings.set('garbage' as RetroTinkSettingName, v)
-      expect(() => profile.setValues(settings)).toThrow(SettingNotSupportedError); 
+      settings.set('garbage' as RetroTinkSettingName, v);
+      expect(() => profile.setValues(settings)).toThrow(SettingNotSupportedError);
     });
   });
   describe('setValue', () => {
@@ -221,7 +221,9 @@ describe('RetroTinkProfile', () => {
         new Uint8Array([250]),
       );
       expect(() => profile.setValue(setting)).toThrow(SettingNotSupportedError);
-      expect(() => profile.setValue('something.unsupported' as RetroTinkSettingName, 'header')).toThrow(SettingNotSupportedError);
+      expect(() => profile.setValue('something.unsupported' as RetroTinkSettingName, 'header')).toThrow(
+        SettingNotSupportedError,
+      );
     });
     test('read-only setting should throw ', async () => {
       const profile = await RetroTinkProfile.build();

--- a/src/profile/RetroTinkProfile.spec.ts
+++ b/src/profile/RetroTinkProfile.spec.ts
@@ -3,6 +3,7 @@ import {
   ProfileNotFoundError,
   SettingDeserializationError,
   SettingNotSupportedError,
+  SettingNotWritableError,
 } from '../exceptions/RetroTinkProfileException';
 import { RetroTinkSetting, RetroTinkSettingValue, RetroTinkSettingsValues } from '../settings/RetroTinkSetting';
 import { RetroTinkSettingName, RetroTinkSettingPath } from '../settings/Schema';
@@ -186,11 +187,23 @@ describe('RetroTinkProfile', () => {
       const profile = await RetroTinkProfile.build();
       const setting = new RetroTinkSettingValue(
         {
-          name: 'something.unsupported' as RetroTinkSettingPath,
+          name: 'something.unsupported' as RetroTinkSettingName,
         } as RetroTinkSetting,
         new Uint8Array([250]),
       );
       expect(() => profile.setValue(setting)).toThrow(SettingNotSupportedError);
+      expect(() => profile.setValue('something.unsupported' as RetroTinkSettingName, 'header')).toThrow(SettingNotSupportedError);
+    });
+    test('read-only setting should throw ', async () => {
+      const profile = await RetroTinkProfile.build();
+      const setting = new RetroTinkSettingValue(
+        {
+          name: 'header' as RetroTinkSettingName,
+        } as RetroTinkSetting,
+        new Uint8Array([250]),
+      );
+      expect(() => profile.setValue(setting)).toThrow(SettingNotWritableError);
+      expect(() => profile.setValue('header' as RetroTinkSettingName, 'primitive')).toThrow(SettingNotWritableError);
     });
   });
   describe('merge', () => {

--- a/src/profile/RetroTinkProfile.spec.ts
+++ b/src/profile/RetroTinkProfile.spec.ts
@@ -90,7 +90,6 @@ describe('RetroTinkProfile', () => {
       profile.deserializeValues(pretty_json_str);
       const settings = profile.getValues();
       expect(settings).toBeInstanceOf(RetroTinkSettingsValues);
-      expect(settings.get('header')?.asString()).toEqual('RT4K Profile');
       expect(settings.get('advanced.effects.mask.enabled')?.asInt()).toEqual(1);
       expect(settings.get('advanced.effects.mask.strength')?.asInt()).toEqual(-4);
       expect(settings.get('advanced.effects.mask.path')?.asString()).toEqual('Mono Masks/A Grille Medium Mono.bmp');
@@ -114,7 +113,6 @@ describe('RetroTinkProfile', () => {
     test('should return the defaults', async () => {
       const profile = await RetroTinkProfile.build();
       const settings = profile.getValues();
-      expect(settings.get('header')?.asString()).toEqual('RT4K Profile');
       expect(settings.get('advanced.effects.mask.enabled')?.asInt()).toEqual(0);
       expect(settings.get('advanced.effects.mask.strength')?.asInt()).toEqual(0);
       expect(settings.get('advanced.effects.mask.path')?.asString()).toEqual('');
@@ -122,7 +120,6 @@ describe('RetroTinkProfile', () => {
     test('should load the settings for whichever file you specify', async () => {
       const profile = await RetroTinkProfile.build(`${__dirname}/__fixtures__/mask-enabled-strength-10.rt4`);
       const settings = profile.getValues();
-      expect(settings.get('header')?.asString()).toEqual('RT4K Profile');
       expect(settings.get('advanced.effects.mask.enabled')?.asInt()).toEqual(1);
       expect(settings.get('advanced.effects.mask.strength')?.asInt()).toEqual(10);
       expect(settings.get('advanced.effects.mask.path')?.asString()).toEqual('');
@@ -145,11 +142,19 @@ describe('RetroTinkProfile', () => {
       let settings = profile.getValues();
       let strength = settings.get('advanced.effects.mask.strength');
       expect(strength?.asInt()).toEqual(0);
-      strength.set(-6);
-      profile.setValues(settings);
+
+      strength.set(-6); // Make the change on the settings value instance...
+      profile.setValue(strength); // ...and send the instance itself to set it
       settings = profile.getValues();
       strength = settings.get('advanced.effects.mask.strength');
       expect(strength?.asInt()).toEqual(-6);
+
+      // Let's make sure we didn't write some code somewhere that derefs the map members
+      strength.set(-3); // Make the change on the settings value instance...
+      profile.setValues(settings); // ...but send the whole map back
+      settings = profile.getValues();
+      strength = settings.get('advanced.effects.mask.strength');
+      expect(strength?.asInt()).toEqual(-3);
     });
   });
   describe('setValue', () => {

--- a/src/profile/RetroTinkProfile.ts
+++ b/src/profile/RetroTinkProfile.ts
@@ -131,7 +131,8 @@ export default class RetroTinkProfile {
   setValues(settings: RetroTinkSettingsValues): void {
     const byte_array = Array.from(this._bytes);
     for (const setting of settings.values()) {
-      if (setting.readOnly) continue;
+      if (!RetroTinkProfile._settings.has(setting.name)) throw new SettingNotSupportedError(setting.name);
+      if (RetroTinkProfile._settings.get(setting.name).readOnly) throw new SettingNotWritableError(setting.name);
       let offset = 0;
       for (const byteRange of setting.byteRanges) {
         byte_array.splice(

--- a/src/profile/RetroTinkProfile.ts
+++ b/src/profile/RetroTinkProfile.ts
@@ -32,7 +32,7 @@ export default class RetroTinkProfile {
   }
 
   static fromBytes(bytes: Uint8Array) {
-    const header = this._settings.get('header');
+    const header = this._settings.get('header' as RetroTinkSettingName);
     const headerValue = new RetroTinkSettingValue(header, RetroTinkProfile.sliceBytes(header, bytes)).asString();
     if (headerValue !== 'RT4K Profile') throw new InvalidProfileFormatError(`Header is invalid: ${headerValue}`);
     return new RetroTinkProfile(bytes);

--- a/src/profile/__fixtures__/json_profiles.ts
+++ b/src/profile/__fixtures__/json_profiles.ts
@@ -1,6 +1,5 @@
-export const unpretty_json_str = `{"header":"RT4K Profile","advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
+export const unpretty_json_str = `{"advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
 export const pretty_json_str = `{
-  "header": "RT4K Profile",
   "advanced": {
     "effects": {
       "mask": {

--- a/src/settings/RetroTinkSetting.spec.ts
+++ b/src/settings/RetroTinkSetting.spec.ts
@@ -262,8 +262,8 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with number', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.path',
+            desc: 'Mask Path',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: DataType.STR,
           });
@@ -275,8 +275,8 @@ describe('RetroTinkSetting', () => {
 
         test('should set with boolean', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.path',
+            desc: 'Mask Path',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: DataType.STR,
           });
@@ -316,8 +316,8 @@ describe('RetroTinkSetting', () => {
 
         test('should throw with unexpected type', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.path',
+            desc: 'Mask Path',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: DataType.STR,
           });
@@ -552,8 +552,8 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with number', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.enabled',
+            desc: 'Mask Enabled',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
           });
@@ -564,8 +564,8 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw for number out of range', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.enabled',
+            desc: 'Mask Enabled',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
           });
@@ -574,8 +574,8 @@ describe('RetroTinkSetting', () => {
         });
         test('should set with boolean', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.enabled',
+            desc: 'Mask Enabled',
             byteRanges: [{ address: 0x0000, length: 1 }],
             type: DataType.BIT,
           });
@@ -602,8 +602,8 @@ describe('RetroTinkSetting', () => {
         });
         test('should throw with unexpected type', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.enabled',
+            desc: 'Mask Enabled',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: DataType.BIT,
           });
@@ -668,8 +668,8 @@ describe('RetroTinkSetting', () => {
       describe('DataType.DOES_NOT_EXIST', () => {
         test('should throw with unexpected type', () => {
           const s = new RetroTinkSetting({
-            name: 'header',
-            desc: 'File Header',
+            name: 'advanced.effects.mask.enabled',
+            desc: 'Mask Enabled',
             byteRanges: [{ address: 0x0000, length: 12 }],
             type: 'DOES_NOT_EXIST' as DataType,
           });

--- a/src/settings/RetroTinkSetting.ts
+++ b/src/settings/RetroTinkSetting.ts
@@ -18,6 +18,7 @@ interface RetroTinkSettingParams {
   byteRanges: ByteRange[];
   type: DataType;
   enums?: RetroTinkEnumValue[];
+  readOnly?: boolean;
 }
 
 interface RetroTinkEnumValue {
@@ -31,6 +32,7 @@ export class RetroTinkSetting {
   byteRanges: ByteRange[];
   type: DataType;
   enums?: RetroTinkEnumValue[];
+  readOnly: boolean = false;
 
   constructor(params: RetroTinkSettingParams) {
     this.name = params.name;
@@ -38,6 +40,7 @@ export class RetroTinkSetting {
     this.byteRanges = params.byteRanges;
     this.type = params.type;
     this.enums = params.enums;
+    this.readOnly = params.readOnly === true ? true : false;
   }
   length(): number {
     return this.byteRanges.reduce((acc, r) => acc + r.length, 0);

--- a/src/settings/RetroTinkSetting.ts
+++ b/src/settings/RetroTinkSetting.ts
@@ -78,6 +78,9 @@ class RetroTinkBaseSettings<T extends RetroTinkSetting> extends Map<string, T> {
     if (!this.has(key)) throw new SettingNotSupportedError(key);
     return super.get(key);
   }
+  set<S extends RetroTinkSettingName>(key: S, value: T) {
+    return super.set(key, value);
+  }
 }
 
 export class RetroTinkSettings extends RetroTinkBaseSettings<RetroTinkSetting> {}

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -26,7 +26,6 @@ type SettingPath<T, K extends keyof T = keyof T> = K extends string
 export type RetroTinkSettingPath = SettingPath<RetroTinkSettingsSchema> | RetroTinkSettingName;
 
 export type RetroTinkSettingsSchema = {
-  header: string;
   input: string;
   output: {
     resolution: string;
@@ -70,8 +69,8 @@ export type RetroTinkSettingsSchema = {
 export const RetroTinkSettingsVersion = {
   '1.4.2': new RetroTinkSettings([
     new RetroTinkSetting({
-      name: 'header',
-      desc: 'File Header',
+      name: 'header' as RetroTinkSettingName,
+      desc: 'File Header (Read-Only)',
       byteRanges: [{ address: 0x0000, length: 12 }],
       type: DataType.STR,
       readOnly: true,

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -74,6 +74,7 @@ export const RetroTinkSettingsVersion = {
       desc: 'File Header',
       byteRanges: [{ address: 0x0000, length: 12 }],
       type: DataType.STR,
+      readOnly: true,
     }),
     new RetroTinkSetting({
       name: 'advanced.effects.mask.enabled',


### PR DESCRIPTION
Previously, clients of the library could set the value of `header`, just like any other setting. What this means is that they could, in practice, create an invalid profile that would not load on a RT4k device.

This fact, along with some insights from reverse engineering the audio input override setting, point to the need for a concept of Read Only settings.

These settings should not be directly set on a profile. For the same reasons, we should remove them from the `RetroTinkSettingsSchema`, as an extra bit of compile-time protection.

If a client attempts to set them on a profile, we will throw a `SettingNotWritableError` exception.