### PR TITLE
Implement Derived, Read-Only Settings (to support audio input override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ outputProfile.saveSync('/path/to/my/new_snes_profile.rt4');
 
 ## Changelog 
 
+### Version 1.1.0 (2024-07-04)
+
+- Added support for the following settings:
+  - `advanced.acquisition.audio_input.sampling.sample_rate`
+  - `advanced.acquisition.audio_input.source.input_override`
+
 ### Version 1.0.1 (2024-07-03)
 
  - Documentation update

--- a/README.md
+++ b/README.md
@@ -103,9 +103,14 @@ outputProfile.saveSync('/path/to/my/new_snes_profile.rt4');
 
 ### Version 1.0.0 (2024-07-03)
 
-- Support `Advanced -> System -> OSD/Firmware -> On Screen Display`
-- Implement `header` as a `RetroTinkReadOnlySetting`
-- Fixed Critical Bug https://github.com/boatmeme/rt4k-profile/issues/26 preventing files saved with this library from loading on RetroTink4k devices
+- There are now **read-only** settings, such as `header`, which should be readable, but cannot be set
+- Profiles saved with this library will now work on the actual device 🤦
+- Added support for the following settings:
+  - `advanced.system.osd_firmware.banner_image.load_banner`
+  - `advanced.system.osd_firmware.on_screen_display.position`
+  - `advanced.system.osd_firmware.on_screen_display.auto_off`
+  - `advanced.system.osd_firmware.on_screen_display.hide_input_res`
+  - `advanced.system.osd_firmware.on_screen_display.enable_debug_osd`
 
 ### Version 0.1.0 (2024-06-29)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ outputProfile.saveSync('/path/to/my/new_snes_profile.rt4');
 
 - Added support for the following settings:
   - `advanced.acquisition.audio_input.sampling.sample_rate`
+  - `advanced.acquisition.audio_input.sampling.preamp_gain`
   - `advanced.acquisition.audio_input.source.input_override`
+  - `advanced.acquisition.audio_input.source.input_swap`
 
 ### Version 1.0.1 (2024-07-03)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt4k-profile",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A Typescript Library for Reading and Writing RetroTINK-4k .rt4 Profiles",
   "main": "dist/index.js",
   "exports": {

--- a/src/profile/RetroTinkProfile.ts
+++ b/src/profile/RetroTinkProfile.ts
@@ -236,7 +236,6 @@ export default class RetroTinkProfile {
   private static CRC_WRITE_INDEX = 32;
   private _getCrc(): Uint8Array {
     const START_INDEX = 128;
-
     const crcValue = CRC16CCITT.calculate(this._bytes, START_INDEX);
     return new Uint8Array([crcValue & 0xff, (crcValue >> 8) & 0xff]);
   }
@@ -262,6 +261,7 @@ export default class RetroTinkProfile {
   }
 
   getCrcString(): string {
+    this._setReadOnlyValues();
     const [lowByte, highByte] = this._getCrc();
     const crcValue = (highByte << 8) | lowByte;
     return `0x${crcValue.toString(16).toUpperCase().padStart(4, '0')}`;

--- a/src/profile/__fixtures__/json_profiles.ts
+++ b/src/profile/__fixtures__/json_profiles.ts
@@ -1,4 +1,4 @@
-export const unpretty_json_str = `{"header":"RT4K Profile","advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
+export const unpretty_json_str = `{"header":"RT4K Profile","advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"acquisition":{"audio_input":{"sampling":{"sample_rate":"48 kHz"},"source":{"input_override":"Off"}}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
 export const pretty_json_str = `{
   "header": "RT4K Profile",
   "advanced": {
@@ -7,6 +7,16 @@ export const pretty_json_str = `{
         "enabled": true,
         "strength": -4,
         "path": "Mono Masks/A Grille Medium Mono.bmp"
+      }
+    },
+    "acquisition": {
+      "audio_input": {
+        "sampling": {
+          "sample_rate": "48 kHz"
+        },
+        "source": {
+          "input_override": "Off"
+        }
       }
     },
     "system": {

--- a/src/profile/__fixtures__/json_profiles.ts
+++ b/src/profile/__fixtures__/json_profiles.ts
@@ -1,4 +1,4 @@
-export const unpretty_json_str = `{"advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"acquisition":{"audio_input":{"sampling":{"sample_rate":"48 kHz"},"source":{"input_override":"Off"}}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
+export const unpretty_json_str = `{"advanced":{"effects":{"mask":{"enabled":true,"strength":-4,"path":"Mono Masks/A Grille Medium Mono.bmp"}},"acquisition":{"audio_input":{"sampling":{"sample_rate":"48 kHz","preamp_gain":"+0.0 dB"},"source":{"input_override":"Off","input_swap":"Off"}}},"system":{"osd_firmware":{"banner_image":{"load_banner":""},"on_screen_display":{"position":"Left","auto_off":"Off","hide_input_res":false,"enable_debug_osd":"Off"}}}},"input":"HDMI","output":{"resolution":"4K60","transmitter":{"hdr":"Off","colorimetry":"Auto-Rec.709","rgb_range":"Full","sync_lock":"Triple Buffer","vrr":"Off","deep_color":false}}}`;
 export const pretty_json_str = `{
   "advanced": {
     "effects": {
@@ -11,10 +11,12 @@ export const pretty_json_str = `{
     "acquisition": {
       "audio_input": {
         "sampling": {
-          "sample_rate": "48 kHz"
+          "sample_rate": "48 kHz",
+          "preamp_gain": "+0.0 dB"
         },
         "source": {
-          "input_override": "Off"
+          "input_override": "Off",
+          "input_swap": "Off"
         }
       }
     },

--- a/src/settings/RetroTinkSetting.ts
+++ b/src/settings/RetroTinkSetting.ts
@@ -20,6 +20,11 @@ interface RetroTinkSettingParams {
   enums?: RetroTinkEnumValue[];
 }
 
+interface RetroTinkReadOnlySettingParams extends RetroTinkSettingParams {
+  derivedFrom: RetroTinkSettingName[];
+  deriveValue: (...values: RetroTinkSettingValue[]) => Uint8Array;
+}
+
 interface RetroTinkEnumValue {
   name: string;
   value: Uint8Array;
@@ -63,7 +68,15 @@ export class RetroTinkSetting {
   }
 }
 
-export class RetroTinkReadOnlySetting extends RetroTinkSetting {}
+export class RetroTinkReadOnlySetting extends RetroTinkSetting {
+  derivedFrom: RetroTinkSettingName[];
+  deriveValue: (...values: RetroTinkSettingValue[]) => Uint8Array;
+  constructor(params: RetroTinkReadOnlySettingParams) {
+    super(params);
+    this.derivedFrom = params.derivedFrom;
+    this.deriveValue = params.deriveValue;
+  }
+}
 
 export type RetroTinkSettingsValuesPlainObject = {
   [key: string]: string | number | boolean | RetroTinkSettingsValuesPlainObject;

--- a/src/settings/Schema.spec.ts
+++ b/src/settings/Schema.spec.ts
@@ -1,0 +1,99 @@
+import { RetroTinkReadOnlySetting, RetroTinkSettingValue } from './RetroTinkSetting';
+import { RetroTinkSettingName, RetroTinkSettingsVersion } from './Schema';
+import { SettingValidationError } from '../exceptions/RetroTinkProfileException';
+
+describe('Schema', () => {
+  describe('1.4.2', () => {
+    describe('derived settings', () => {
+      describe('input.audio', () => {
+        it('should vary with input', () => {
+          const settings = RetroTinkSettingsVersion['1.4.2'];
+          const inputs = settings.get('input').enums?.reduce((acc, e) => ({ ...acc, [e.name]: e.value }), {}) || {};
+          const audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            new Uint8Array([0]),
+          );
+          const input_audio = <RetroTinkReadOnlySetting>settings.get('input.audio' as RetroTinkSettingName);
+
+          let input = new RetroTinkSettingValue(settings.get('input'), inputs['HDMI']);
+          let [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(5);
+
+          input = new RetroTinkSettingValue(settings.get('input'), inputs['Front|Composite']);
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(3);
+
+          input = new RetroTinkSettingValue(settings.get('input'), inputs['RCA|RGsB']);
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(0);
+
+          input = new RetroTinkSettingValue(settings.get('input'), inputs['SCART|YPbPr']);
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(2);
+
+          input = new RetroTinkSettingValue(settings.get('input'), inputs['HD-15|RGBHV']);
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(1);
+        });
+        it('should vary with audio input override', () => {
+          const settings = RetroTinkSettingsVersion['1.4.2'];
+          const inputs = settings.get('input').enums?.reduce((acc, e) => ({ ...acc, [e.name]: e.value }), {}) || {};
+          const inputOverrides =
+            settings
+              .get('advanced.acquisition.audio_input.source.input_override')
+              .enums?.reduce((acc, e) => ({ ...acc, [e.name]: e.value }), {}) || {};
+          const input_audio = <RetroTinkReadOnlySetting>settings.get('input.audio' as RetroTinkSettingName);
+          const input = new RetroTinkSettingValue(settings.get('input'), inputs['HDMI']);
+
+          let audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            inputOverrides['RCA'],
+          );
+          let [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(0);
+
+          audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            inputOverrides['HD-15'],
+          );
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(1);
+
+          audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            inputOverrides['SCART'],
+          );
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(2);
+
+          audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            inputOverrides['Front'],
+          );
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(3);
+
+          audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            inputOverrides['S/PDIF'],
+          );
+          [value] = input_audio.deriveValue(audio_input_override, input);
+          expect(value).toEqual(4);
+        });
+
+        it('should throw if there is a bad input value', () => {
+          const settings = RetroTinkSettingsVersion['1.4.2'];
+          const audio_input_override = new RetroTinkSettingValue(
+            settings.get('advanced.acquisition.audio_input.source.input_override'),
+            new Uint8Array([0]),
+          );
+          const input_audio = <RetroTinkReadOnlySetting>settings.get('input.audio' as RetroTinkSettingName);
+
+          expect(() =>
+            input_audio.deriveValue(audio_input_override, { asInt: () => 69 } as RetroTinkSettingValue),
+          ).toThrow(SettingValidationError);
+        });
+      });
+    });
+  });
+});

--- a/src/settings/Schema.spec.ts
+++ b/src/settings/Schema.spec.ts
@@ -95,5 +95,19 @@ describe('Schema', () => {
         });
       });
     });
+    describe('dynamically generated values', () => {
+      describe('advanced.acquisition.audio_input.sampling.preamp_gain', () => {
+        const settings = RetroTinkSettingsVersion['1.4.2'];
+        const gain = settings.get('advanced.acquisition.audio_input.sampling.preamp_gain');
+        const first = gain.enums?.find(({ name }) => name == '-24.0 dB');
+        const last = gain.enums?.find(({ name }) => name == '+28.0 dB');
+        const middle = gain.enums?.find(({ name }) => name == '+0.0 dB');
+
+        expect(gain.enums?.length).toBe(105);
+        expect(first?.value).toEqual(new Uint8Array([208]));
+        expect(last?.value).toEqual(new Uint8Array([56]));
+        expect(middle?.value).toEqual(new Uint8Array([0]));
+      });
+    });
   });
 });

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -60,9 +60,11 @@ export type RetroTinkSettingsSchema = {
       audio_input: {
         sampling: {
           sample_rate: string;
+          preamp_gain: string;
         };
         source: {
           input_override: string;
+          input_swap: string;
         };
       };
     };
@@ -120,6 +122,17 @@ export const RetroTinkSettingsVersion = {
         { name: '96 kHz', value: new Uint8Array([1]) },
       ],
     }),
+    new RetroTinkSetting({
+      name: 'advanced.acquisition.audio_input.sampling.preamp_gain',
+      desc: 'Advanced -> Acquisition -> Audio Input -> Sampling -> Pre-amp Gain',
+      byteRanges: [{ address: 0x1610, length: 1 }],
+      type: DataType.ENUM,
+      // Generates 105 enum entries for pre-amp gain from -24.0 dB to +28.0 dB in 0.5 dB steps
+      enums: Array.from({ length: 105 }, (_, i) => ({
+        name: `${i * 0.5 - 24 >= 0 ? '+' : ''}${(i * 0.5 - 24).toFixed(1)} dB`,
+        value: new Uint8Array([(208 + i) & 255]),
+      })),
+    }),
     new RetroTinkReadOnlySetting({
       name: 'input.audio' as RetroTinkSettingName,
       desc: 'Audio Input (Read-Only)',
@@ -161,6 +174,18 @@ export const RetroTinkSettingsVersion = {
         { name: 'SCART', value: new Uint8Array([3]) },
         { name: 'Front', value: new Uint8Array([4]) },
         { name: 'S/PDIF', value: new Uint8Array([5]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.acquisition.audio_input.source.input_swap',
+      desc: 'Advanced -> Acquisition -> Audio Input -> Source -> Input Swap',
+      byteRanges: [{ address: 0x1620, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Off', value: new Uint8Array([0]) },
+        { name: 'Mono (Left)', value: new Uint8Array([1]) },
+        { name: 'Mono (Right)', value: new Uint8Array([2]) },
+        { name: 'L/R Swap', value: new Uint8Array([3]) },
       ],
     }),
     new RetroTinkSetting({

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -51,6 +51,16 @@ export type RetroTinkSettingsSchema = {
         strength: number;
       };
     };
+    acquisition: {
+      audio_input: {
+        sampling: {
+          sample_rate: string;
+        };
+        source: {
+          input_override: string;
+        };
+      };
+    };
     system: {
       osd_firmware: {
         banner_image: {
@@ -92,6 +102,30 @@ export const RetroTinkSettingsVersion = {
       desc: 'Advanced -> Processing -> Mask -> Path',
       byteRanges: [{ address: 0x0090, length: 256 }],
       type: DataType.STR,
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.acquisition.audio_input.sampling.sample_rate',
+      desc: 'Advanced -> Acquisition -> Audio Input -> Sampling -> Sample Rate',
+      byteRanges: [{ address: 0x1624, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: '48 kHz', value: new Uint8Array([0]) },
+        { name: '96 kHz', value: new Uint8Array([1]) },
+      ],
+    }),
+    new RetroTinkSetting({
+      name: 'advanced.acquisition.audio_input.source.input_override',
+      desc: 'Advanced -> Acquisition -> Audio Input -> Source -> Input Override',
+      byteRanges: [{ address: 0x1618, length: 1 }],
+      type: DataType.ENUM,
+      enums: [
+        { name: 'Off', value: new Uint8Array([0]) },
+        { name: 'RCA', value: new Uint8Array([1]) },
+        { name: 'HD-15', value: new Uint8Array([2]) },
+        { name: 'SCART', value: new Uint8Array([3]) },
+        { name: 'Front', value: new Uint8Array([4]) },
+        { name: 'S/PDIF', value: new Uint8Array([5]) },
+      ],
     }),
     new RetroTinkSetting({
       name: 'advanced.system.osd_firmware.banner_image.load_banner',

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -83,6 +83,8 @@ export const RetroTinkSettingsVersion = {
       desc: 'File Header (Read-Only)',
       byteRanges: [{ address: 0x0000, length: 12 }],
       type: DataType.STR,
+      derivedFrom: [],
+      deriveValue: () => new Uint8Array([82, 84, 52, 75, 32, 80, 114, 111, 102, 105, 108, 101]),
     }),
     new RetroTinkSetting({
       name: 'advanced.effects.mask.enabled',

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -128,7 +128,6 @@ export const RetroTinkSettingsVersion = {
       deriveValue: (...[audio_input_override, source_input]: RetroTinkSettingValue[]) => {
         const overrideVal = audio_input_override.asInt();
         const sourceVal = source_input.asInt();
-        console.log(audio_input_override, source_input);
         if (overrideVal == 0) {
           switch (sourceVal) {
             case 0:

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -1,3 +1,4 @@
+import { SettingValidationError } from '../exceptions/RetroTinkProfileException';
 import { DataType } from './DataType';
 import {
   RetroTinkReadOnlySetting,
@@ -129,47 +130,19 @@ export const RetroTinkSettingsVersion = {
         const overrideVal = audio_input_override.asInt();
         const sourceVal = source_input.asInt();
         if (overrideVal == 0) {
-          switch (sourceVal) {
-            case 0:
+          switch (true) {
+            case sourceVal === 0:
               return new Uint8Array([5]);
-            case 3:
+            case [3, 4].includes(sourceVal):
               return new Uint8Array([3]);
-            case 4:
-              return new Uint8Array([3]);
-            case 7:
+            case [7, 8, 9].includes(sourceVal):
               return new Uint8Array([0]);
-            case 8:
-              return new Uint8Array([0]);
-            case 9:
-              return new Uint8Array([0]);
-            case 12:
+            case [12, 13, 14, 15, 16, 17].includes(sourceVal):
               return new Uint8Array([2]);
-            case 13:
-              return new Uint8Array([2]);
-            case 14:
-              return new Uint8Array([2]);
-            case 15:
-              return new Uint8Array([2]);
-            case 16:
-              return new Uint8Array([2]);
-            case 17:
-              return new Uint8Array([2]);
-            case 20:
+            case [20, 21, 22, 23, 24, 25, 26, 27].includes(sourceVal):
               return new Uint8Array([1]);
-            case 21:
-              return new Uint8Array([1]);
-            case 22:
-              return new Uint8Array([1]);
-            case 23:
-              return new Uint8Array([1]);
-            case 24:
-              return new Uint8Array([1]);
-            case 25:
-              return new Uint8Array([1]);
-            case 26:
-              return new Uint8Array([1]);
-            case 27:
-              return new Uint8Array([1]);
+            default:
+              throw new SettingValidationError('input', sourceVal, `unexpected 'input' value`);
           }
         } else {
           return new Uint8Array([overrideVal - 1]);

--- a/src/settings/Schema.ts
+++ b/src/settings/Schema.ts
@@ -1,5 +1,10 @@
 import { DataType } from './DataType';
-import { RetroTinkReadOnlySetting, RetroTinkSetting, RetroTinkSettings } from './RetroTinkSetting';
+import {
+  RetroTinkReadOnlySetting,
+  RetroTinkSetting,
+  RetroTinkSettingValue,
+  RetroTinkSettings,
+} from './RetroTinkSetting';
 
 export type Primitive = string | number | boolean;
 
@@ -114,6 +119,64 @@ export const RetroTinkSettingsVersion = {
         { name: '96 kHz', value: new Uint8Array([1]) },
       ],
     }),
+    new RetroTinkReadOnlySetting({
+      name: 'input.audio' as RetroTinkSettingName,
+      desc: 'Audio Input (Read-Only)',
+      byteRanges: [{ address: 0x0368, length: 1 }],
+      type: DataType.INT,
+      derivedFrom: ['advanced.acquisition.audio_input.source.input_override', 'input'],
+      deriveValue: (...[audio_input_override, source_input]: RetroTinkSettingValue[]) => {
+        const overrideVal = audio_input_override.asInt();
+        const sourceVal = source_input.asInt();
+        console.log(audio_input_override, source_input);
+        if (overrideVal == 0) {
+          switch (sourceVal) {
+            case 0:
+              return new Uint8Array([5]);
+            case 3:
+              return new Uint8Array([3]);
+            case 4:
+              return new Uint8Array([3]);
+            case 7:
+              return new Uint8Array([0]);
+            case 8:
+              return new Uint8Array([0]);
+            case 9:
+              return new Uint8Array([0]);
+            case 12:
+              return new Uint8Array([2]);
+            case 13:
+              return new Uint8Array([2]);
+            case 14:
+              return new Uint8Array([2]);
+            case 15:
+              return new Uint8Array([2]);
+            case 16:
+              return new Uint8Array([2]);
+            case 17:
+              return new Uint8Array([2]);
+            case 20:
+              return new Uint8Array([1]);
+            case 21:
+              return new Uint8Array([1]);
+            case 22:
+              return new Uint8Array([1]);
+            case 23:
+              return new Uint8Array([1]);
+            case 24:
+              return new Uint8Array([1]);
+            case 25:
+              return new Uint8Array([1]);
+            case 26:
+              return new Uint8Array([1]);
+            case 27:
+              return new Uint8Array([1]);
+          }
+        } else {
+          return new Uint8Array([overrideVal - 1]);
+        }
+      },
+    }),
     new RetroTinkSetting({
       name: 'advanced.acquisition.audio_input.source.input_override',
       desc: 'Advanced -> Acquisition -> Audio Input -> Source -> Input Override',
@@ -186,32 +249,29 @@ export const RetroTinkSettingsVersion = {
     new RetroTinkSetting({
       name: 'input',
       desc: 'Input',
-      byteRanges: [
-        { address: 0x0368, length: 1 },
-        { address: 0x5869, length: 1 },
-      ],
+      byteRanges: [{ address: 0x5869, length: 1 }],
       type: DataType.ENUM,
       enums: [
-        { name: 'HDMI', value: new Uint8Array([5, 0]) },
-        { name: 'Front|Composite', value: new Uint8Array([3, 3]) },
-        { name: 'Front|S-Video', value: new Uint8Array([3, 4]) },
-        { name: 'RCA|YPbPr', value: new Uint8Array([0, 7]) },
-        { name: 'RCA|RGsB', value: new Uint8Array([0, 8]) },
-        { name: 'RCA|CVBS on Green', value: new Uint8Array([0, 9]) },
-        { name: 'SCART|RGBS (75 Ohm)', value: new Uint8Array([2, 12]) },
-        { name: 'SCART|RGsB', value: new Uint8Array([2, 13]) },
-        { name: 'SCART|YPbPr', value: new Uint8Array([2, 14]) },
-        { name: 'SCART|CVBS on Pin 20', value: new Uint8Array([2, 15]) },
-        { name: 'SCART|CVBS on Green', value: new Uint8Array([2, 16]) },
-        { name: 'SCART|Y/C on Pin 20/Red', value: new Uint8Array([2, 17]) },
-        { name: 'HD-15|RGBHV', value: new Uint8Array([1, 20]) },
-        { name: 'HD-15|RGBS', value: new Uint8Array([1, 21]) },
-        { name: 'HD-15|RGsB', value: new Uint8Array([1, 22]) },
-        { name: 'HD-15|YPbPr', value: new Uint8Array([1, 23]) },
-        { name: 'HD-15|CVBS on Hsync', value: new Uint8Array([1, 24]) },
-        { name: 'HD-15|CVBS on Green', value: new Uint8Array([1, 25]) },
-        { name: 'HD-15|Y/C on Green/Red', value: new Uint8Array([1, 26]) },
-        { name: 'HD-15|Y/C on G/R (Enh.)', value: new Uint8Array([1, 27]) },
+        { name: 'HDMI', value: new Uint8Array([0]) },
+        { name: 'Front|Composite', value: new Uint8Array([3]) },
+        { name: 'Front|S-Video', value: new Uint8Array([4]) },
+        { name: 'RCA|YPbPr', value: new Uint8Array([7]) },
+        { name: 'RCA|RGsB', value: new Uint8Array([8]) },
+        { name: 'RCA|CVBS on Green', value: new Uint8Array([9]) },
+        { name: 'SCART|RGBS (75 Ohm)', value: new Uint8Array([12]) },
+        { name: 'SCART|RGsB', value: new Uint8Array([13]) },
+        { name: 'SCART|YPbPr', value: new Uint8Array([14]) },
+        { name: 'SCART|CVBS on Pin 20', value: new Uint8Array([15]) },
+        { name: 'SCART|CVBS on Green', value: new Uint8Array([16]) },
+        { name: 'SCART|Y/C on Pin 20/Red', value: new Uint8Array([17]) },
+        { name: 'HD-15|RGBHV', value: new Uint8Array([20]) },
+        { name: 'HD-15|RGBS', value: new Uint8Array([21]) },
+        { name: 'HD-15|RGsB', value: new Uint8Array([22]) },
+        { name: 'HD-15|YPbPr', value: new Uint8Array([23]) },
+        { name: 'HD-15|CVBS on Hsync', value: new Uint8Array([24]) },
+        { name: 'HD-15|CVBS on Green', value: new Uint8Array([25]) },
+        { name: 'HD-15|Y/C on Green/Red', value: new Uint8Array([26]) },
+        { name: 'HD-15|Y/C on G/R (Enh.)', value: new Uint8Array([27]) },
       ],
     }),
     new RetroTinkSetting({


### PR DESCRIPTION
Because of the observed interaction between the Audio Input Override setting, the Input setting, and a third, as-yet-unidentified  byte (assuming it is the true "audio input" value), I saw the need for a concept of a "derived" setting abstraction, which can take the values of multiple, distinct, public-facing settings and use that to calculate a value for its own byte location(s). 

I believe it makes sense to build that on top of the existing `RetroTinkReadOnlySetting` abstraction as these settings/values aren't directly settable by the interface anyway.

After adding the abstraction, I was then able to successfully implement all of the audio settings, including the read-only, derived setting, `audio.input`.